### PR TITLE
fix: node23 module not defined, change to default export

### DIFF
--- a/pkg/tailwind.go
+++ b/pkg/tailwind.go
@@ -16,7 +16,7 @@ const tailwindCSSInput = `
 
 // Tailwind configuration in JSON format (customize paths and settings as needed)
 const tailwindConfig = `
-module.exports = {
+export default {
   content: ["./frontend/src/**/*.tsx"],
   theme: {
     extend: {}
@@ -39,7 +39,6 @@ func Tailwind(baseDir string) string {
 	if err := os.WriteFile(inputCSSPath, []byte(tailwindCSSInput), 0644); err != nil {
 		log.Fatalf("Failed to write input.css: %v", err)
 	}
-
 
 	// Run Tailwind CSS using npx, specifying input and output paths
 	cmd := exec.Command("npx", "tailwindcss", "-i", inputCSSPath, "-o", outputCSSPath, "--config", config, "--minify")


### PR DESCRIPTION
for node 23.1, module is not defined.  Fix by changing to "export default" in tailwind config

```
file:///var/home/bjk/projects/omnius/lunaexample/frontend/tailwind.config.js:2
module.exports = {
^

ReferenceError: module is not defined
    at file:///var/home/bjk/projects/omnius/lunaexample/frontend/tailwind.config.js:2:1
    at ModuleJobSync.runSync (node:internal/modules/esm/module_job:367:35)
    at ModuleLoader.importSyncForRequire (node:internal/modules/esm/loader:325:47)
    at loadESMFromCJS (node:internal/modules/cjs/loader:1396:24)
    at Module._compile (node:internal/modules/cjs/loader:1529:5)
    at Object..js (node:internal/modules/cjs/loader:1678:16)
    at Module.load (node:internal/modules/cjs/loader:1315:32)
    at Function._load (node:internal/modules/cjs/loader:1125:12)
    at TracingChannel.traceSync (node:diagnostics_channel:322:14)
    at wrapModuleLoad (node:internal/modules/cjs/loader:216:24)
```